### PR TITLE
Allow building with primitive-0.6

### DIFF
--- a/System/Random/MWC.hs
+++ b/System/Random/MWC.hs
@@ -99,6 +99,9 @@ module System.Random.MWC
 
 import Control.Monad           (ap, liftM, unless)
 import Control.Monad.Primitive (PrimMonad, PrimState, unsafePrimToIO)
+#if MIN_VERSION_primitive(0,6,0)
+import Control.Monad.Primitive (PrimBase)
+#endif
 import Control.Monad.ST        (ST)
 import Data.Bits               (Bits, (.&.), (.|.), shiftL, shiftR, xor)
 import Data.Int                (Int8, Int16, Int32, Int64)
@@ -428,7 +431,13 @@ acquireSeedSystem = do
 -- Cryptographic API as a source of random numbers (it uses the system
 -- clock instead). As a result, the sequences it generates may not be
 -- highly independent.
-withSystemRandom :: PrimMonad m => (Gen (PrimState m) -> m a) -> IO a
+withSystemRandom ::
+#if MIN_VERSION_primitive(0,6,0)
+                    (PrimBase m, PrimMonad m)
+#else
+                    PrimMonad m
+#endif
+                 => (Gen (PrimState m) -> m a) -> IO a
 withSystemRandom act = do
   seed <- acquireSeedSystem `E.catch` \(_::E.IOException) -> do
     seen <- atomicModifyIORef warned ((,) True)

--- a/System/Random/MWC.hs
+++ b/System/Random/MWC.hs
@@ -433,7 +433,7 @@ acquireSeedSystem = do
 -- highly independent.
 withSystemRandom ::
 #if MIN_VERSION_primitive(0,6,0)
-                    (PrimBase m, PrimMonad m)
+                    PrimBase m
 #else
                     PrimMonad m
 #endif


### PR DESCRIPTION
`primitive-0.6` splits the `PrimMonad` class into two classes, `PrimMonad` and `PrimBase`. `unsafePrimToIO` now only requires a `PrimBase` constraint, so I used CPP pragmas to conditionally constraint the type signature of `withSystemRandom` (since `primitive` is part of the Haskell Platform).