### PR TITLE
Don't force -auto-all

### DIFF
--- a/mwc-random.cabal
+++ b/mwc-random.cabal
@@ -50,9 +50,6 @@ library
     build-depends:
       base >= 4
 
-  -- gather extensive profiling data for now
-  ghc-prof-options: -auto-all
-
   ghc-options: -Wall -funbox-strict-fields
   if impl(ghc >= 6.8)
     ghc-options: -fwarn-tabs


### PR DESCRIPTION
Cabal now allows you to set profiling detail in a more fine-grained way using
`--profiling-detail`.

Forcing `-auto-all` significantly decreases the signal-to-noise when profiling a larger project using `mwc-random`.